### PR TITLE
Project Roles Styling + Past Speakers Styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -734,19 +734,47 @@ header .intro-text {
 
 .role-card {
     display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+    border-radius: center;
+    padding: 10px;
     margin: 2em 1em 2em 1em;
 }
 
+.centerRoleInfo {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+    width: 60em;
+    border-radius: 30px;
+    padding: 2em;
+    background: rgb(235, 235, 235);
+    box-shadow: 0 0 15px #3336;
+}
+
+.centerRole {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+}
+
 .role-title {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+    border-radius: center;
     margin: 2em;
-    padding-right: 2em;
     font-size: 20px;
     color: #333;
     font-weight: 600;
-    display: flex;
-    flex-direction: row;
     width: 8em;
     max-height: 100px;
 }
@@ -765,6 +793,35 @@ header .intro-text {
 
 .descText {
     color: black;
+}
+
+.roleCard {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+    width: 30em;
+    border-radius: 40px;
+    padding: 2.5em;
+    font-size: 1em;
+    font-weight: 400;
+    color: black;
+    background: linear-gradient(
+        to right,
+        rgb(193, 221, 253),
+        rgb(173, 208, 253)
+    );
+    box-shadow: 0 0 15px #3336;
+}
+
+.speakerTextSize {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    text-align: center;
+    flex-wrap: wrap;
+    font-size: 1em;
 }
 
 /* .shade {
@@ -799,7 +856,7 @@ header .intro-text {
   }
 } */
 
-@media (max-width: 674px) {
+/*@media (max-width: 674px) {
     .role-card {
         flex-direction: column;
     }
@@ -867,7 +924,7 @@ header .intro-text {
             background-color: white;
         }
     }
-}
+}*/
 
 @media (min-width: 675px) {
     .default {
@@ -1059,7 +1116,6 @@ header .intro-text {
     padding: 20px;
     box-shadow: 0 0 22px #3336;
     border-radius: 30px;
-    height: 12em;
     background-color: #ebebeb;
 }
 
@@ -1084,11 +1140,11 @@ header .intro-text {
     display: flex;
     flex-direction: column;
     flex-basis: 40%;
-    font-size: 1em;
+    font-size: 0.7em;
 }
 
 .person-text h3 {
-    font-size: 2em;
+    font-size: 2.2em;
     color: #2f5f93;
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -749,7 +749,7 @@ header .intro-text {
     align-items: center;
     text-align: center;
     flex-wrap: wrap;
-    width: 60em;
+    width: 90vw;
     border-radius: 30px;
     padding: 2em;
     background: rgb(235, 235, 235);

--- a/src/components/person.jsx
+++ b/src/components/person.jsx
@@ -8,16 +8,22 @@ export const Person = (props) => {
             <img src={props.image} alt="" className="speaker-img" />
             <div className="person-text">
                 <h3>{props.name}</h3>
-                <span>{props.title}</span>
+                <span className="speakerText">{props.title}</span>
             </div>
-            <a href={props.ld ? props.ld : '/'} target='_blank' rel='noreferrer'>
-                <i className='fa fa-linkedin fa-2x'></i>
+            <a
+                href={props.ld ? props.ld : "/"}
+                target="_blank"
+                rel="noreferrer"
+            >
+                <i className="fa fa-linkedin fa-2x"></i>
             </a>
-            <a href={props.tw ? props.tw : '/'} target='_blank' rel='noreferrer'>
-                <i className='fa fa-twitter fa-2x'></i>
+            <a
+                href={props.tw ? props.tw : "/"}
+                target="_blank"
+                rel="noreferrer"
+            >
+                <i className="fa fa-twitter fa-2x"></i>
             </a>
         </div>
     );
 };
-
-

--- a/src/components/projRoles.jsx
+++ b/src/components/projRoles.jsx
@@ -2,18 +2,17 @@ import { useEffect } from "react";
 import { useState } from "react";
 
 function RoleCard(props) {
-
     const [hover, setHover] = useState({
         hover: false,
-        load: false
+        load: false,
     });
 
     useEffect(() => {
         setHover({
             hover: false,
-            load: false
-        })
-    },[])
+            load: false,
+        });
+    }, []);
 
     function setClass() {
         if (hover.hover) {
@@ -26,9 +25,9 @@ function RoleCard(props) {
 
     function visibility() {
         if (hover.hover) {
-            return "descText fade-in"
+            return "descText fade-in";
         } else if (hover.load) {
-            return "descText fade-out"
+            return "descText fade-out";
         }
         return "descText";
     }
@@ -37,13 +36,13 @@ function RoleCard(props) {
         if (hover.hover) {
             setHover({
                 hover: false,
-                load: true
+                load: true,
             });
         } else {
             setHover({
                 hover: true,
-                load: true
-            })
+                load: true,
+            });
         }
     }
 
@@ -51,11 +50,14 @@ function RoleCard(props) {
         <div>
             <div className="role-card">
                 <div className="role-title">
-                    <div className='btn-custom page-scroll'>
+                    <div className="btn-custom page-scroll">
                         {props.data.title}
                     </div>
                 </div>
-                <div className={visibility()} style={{'backgroundColor':'rgba(99, 114, 255, 0.5)'}}>
+                <div
+                    className="roleCard"
+                    style={{ backgroundColor: "rgba(99, 114, 255, 0.5)" }}
+                >
                     {props.data.desc}
                 </div>
             </div>
@@ -63,25 +65,43 @@ function RoleCard(props) {
     );
 }
 
-
-
 export const ProjRoles = (props) => {
-
     return (
-        <div className=" project-roles container">
-            <div className="row" style={{'marginBottom':'5em'}}>
+        <div>
+            <div style={{ marginBottom: "5em" }}>
                 {/* <div className="project-img">
                     <img src="../img/project_team.png" alt="project" />
                 </div> */}
-                <h1 style={{textAlign: 'center',color: '#6372ff', margin: '2em 1em 2em 1em'}}>Project roles</h1>
-                <h3 >Learn more about each of the 3 roles every project has! 
-                    Each role has workshops that help
-                    students develop production-level code. <span style={{'color':'#6372ff'}}></span>
-                </h3>
-                <RoleCard data={props.data.analysisRole}></RoleCard>
-                <RoleCard data={props.data.platformRole}></RoleCard>
-                <RoleCard data={props.data.datavizRole}></RoleCard>
+                <h1
+                    style={{
+                        textAlign: "center",
+                        color: "#6372ff",
+                        margin: "2em 1em 1em 1em",
+                    }}
+                >
+                    Project roles
+                </h1>
+                <span className="centerRole">
+                    <h3 className="centerRoleInfo">
+                        Learn more about each of the 3 roles every project has!
+                        Each role has workshops that help students develop
+                        production-level code.{" "}
+                        <span style={{ color: "#6372ff" }}></span>
+                    </h3>
+                </span>
+                <RoleCard
+                    data={props.data.analysisRole}
+                    className="roleCard"
+                ></RoleCard>
+                <RoleCard
+                    data={props.data.platformRole}
+                    className="roleCard"
+                ></RoleCard>
+                <RoleCard
+                    data={props.data.datavizRole}
+                    className="roleCard"
+                ></RoleCard>
             </div>
         </div>
     );
-}
+};


### PR DESCRIPTION
The following changes were made:
- A reorganized layout of the roles section
- Completed redone styling of the Name of Role, Short Description, and Section Description
- Fully responsive in all layouts:
(Normal Windows Display)
![image](https://user-images.githubusercontent.com/109838832/200097726-b4ccdebe-4196-4130-9b88-4c07e8ef8b7e.png)
(Surface Duo Display)
![image](https://user-images.githubusercontent.com/109838832/200097967-02a7dd5c-9bdc-427f-8a12-3c817a3fbfd9.png)
- Noticed that Past Speakers Styling was not 100% responsive so made needed changes to make it fully responsive:
(Normal Windows Display)
![image](https://user-images.githubusercontent.com/109838832/200097730-8d8f11c1-3586-42a5-86b8-4a57698bf627.png)
(Surface Duo Display)
![image](https://user-images.githubusercontent.com/109838832/200097992-fe342929-b221-4528-98b8-04b85bbe65a3.png)

Hope this works!
-Tyler