### PR TITLE
Centered the linkedin icon

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1575,8 +1575,8 @@ label {
 }
 /* alumni only has linkedlin, therefore left is removed in order to set the icon center*/
 #alumni .social-link {
-    position: absolute;
-    top: 75px;
+    /* position: absolute; */
+    top: 30px;
     /* left: 42px; */
 }
 

--- a/src/components/AlumniPage.jsx
+++ b/src/components/AlumniPage.jsx
@@ -60,7 +60,7 @@ export const AlumniPage = (props) => {
             {JsonData.Alumni
               ? JsonData.Alumni.map((d, i) => (
                 <div className='card col-xs-4'>
-                  <img alt="" src={d.img} />
+                  <img alt="" src={d.img} style={{marginTop:'35px'}}/>
                   <div className='caption'>
                     <h4>{d.name}</h4>
                     <p>{d.title}</p>


### PR DESCRIPTION
I set the Linkedin icon at the center of the rectangle. Also I little bit lowered the location of images of alumnus because compared to the leadership page, we don't have their position title and other links and the card looked too empty. By lowering the images, the card looks full.

**Alumni Page**
![image](https://user-images.githubusercontent.com/37010657/200189015-94d8918b-86cf-42f7-8cb5-90a4ec61f7d2.png)

**Leadership Page**
![image](https://user-images.githubusercontent.com/37010657/200189029-efdb64ff-6929-4ba5-93c2-a352ef94433f.png)
